### PR TITLE
Two bug fixes for message leak and image read

### DIFF
--- a/src/fah/viewer/PPM.cpp
+++ b/src/fah/viewer/PPM.cpp
@@ -71,7 +71,7 @@ void PPM::parse(const uint8_t *data, uint64_t length) {
   while (isspace(*data)) data++;
 
   // Comment
-  if (*data == '#') {
+  while (*data == '#') {
     while (*data != '\n') data++;
     while (isspace(*data)) data++;
   }


### PR DESCRIPTION
Two bug fixes in this pull request:

1. Fix for the viewer slowly falling behind the client's progress.  Caused by the viewer only reading one message at a time from its buffer even when the client sends more than one.  This was also a slow memory leak as the buffer steadily grows over time holding these delayed message.

2. Fix a crash running Advanced Modes unless the default background is turned off.