### PR TITLE
Fix handling of radius value of -1 from client

### DIFF
--- a/src/fah/viewer/Atom.cpp
+++ b/src/fah/viewer/Atom.cpp
@@ -170,6 +170,7 @@ void Atom::loadJSON(const JSON::Value &value, float scale) {
 
   if (!number) number = numberFromName(type);
   if (!charge) charge = chargeFromNumber(number);
-  if (!radius) radius = radiusFromNumber(number);
+  //  Client sends radius value of -1 as a default
+  if (radius < 0) radius = radiusFromNumber(number);
   if (!mass) mass = massFromNumber(number);
 }


### PR DESCRIPTION
The client is sending radius values of -1 from Gromacs cores.  The viewer doesn't handle this well and the result is that all atoms have the same radius.  This fixes it by replacing the -1 value with the default for the specific atom type.  So now you see small H atoms and large S atoms.